### PR TITLE
feat: track "Start building" and "Documentation" event

### DIFF
--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -4,6 +4,7 @@ import styles from "./styles.module.scss";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Start from "@site/src/components/Start";
+import { trackEvent } from "@site/src/providers/analytics.providers";
 
 export default function Hero(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
@@ -20,9 +21,18 @@ export default function Hero(): JSX.Element {
         </p>
         <p className={`${styles.item}`}></p>
         <div className={`${styles.item} ${styles.actions}`}>
-          <Start />
+          <Start position="hero" />
 
-          <Link className="button button--juno" to="/docs/intro">
+          <Link
+            className="button button--juno"
+            to="/docs/intro"
+            onClick={() =>
+              trackEvent({
+                name: "documentation",
+                siteConfig,
+              })
+            }
+          >
             Documentation
           </Link>
         </div>

--- a/src/components/Outro/index.tsx
+++ b/src/components/Outro/index.tsx
@@ -10,7 +10,7 @@ export default function Outro(): JSX.Element {
         <span className={styles.bold}>no time</span>.
       </p>
 
-      <Start />
+      <Start position="footer" />
     </div>
   );
 }

--- a/src/components/Start/index.tsx
+++ b/src/components/Start/index.tsx
@@ -1,13 +1,25 @@
 import React from "react";
-import Snippet from "@site/src/components/Snippet";
 import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { trackEvent } from "../../providers/analytics.providers";
 
-export default function Start(): JSX.Element {
+export default function Start({position}): JSX.Element {
+  const { siteConfig } = useDocusaurusContext();
+
   return (
     <Link
       className="button button--hero"
       href="https://console.juno.build"
       target="_self"
+      onClick={() =>
+        trackEvent({
+          name: "start_building",
+          metadata: {
+            position,
+          },
+          siteConfig,
+        })
+      }
     >
       Start building
     </Link>

--- a/src/providers/analytics.providers.ts
+++ b/src/providers/analytics.providers.ts
@@ -9,13 +9,13 @@ export const trackEvent = async ({
   name: string;
   metadata?: Record<string, string>
   siteConfig: DocusaurusConfig;
-}) => {
+}): Promise<boolean> => {
   const {
     customFields: { dev },
   } = siteConfig;
 
   if (dev) {
-    return;
+    return false;
   }
 
   await trackEventOrbiter({

--- a/src/providers/analytics.providers.ts
+++ b/src/providers/analytics.providers.ts
@@ -1,0 +1,27 @@
+import { trackEvent as trackEventOrbiter } from "@junobuild/analytics";
+import type { DocusaurusConfig } from "@docusaurus/types";
+
+export const trackEvent = async ({
+  name,
+  metadata,
+  siteConfig,
+}: {
+  name: string;
+  metadata?: Record<string, string>
+  siteConfig: DocusaurusConfig;
+}) => {
+  const {
+    customFields: { dev },
+  } = siteConfig;
+
+  if (dev) {
+    return;
+  }
+
+  await trackEventOrbiter({
+    name,
+    metadata
+  });
+
+  return true;
+};


### PR DESCRIPTION
I'm curious to see how the `trackEvent` feature would work if applied to external link and also interested to know if the call to action of the main page of the documentation are used.