### PR TITLE
Added the return type for listAssets and listDocs

### DIFF
--- a/docs/build/datastore.md
+++ b/docs/build/datastore.md
@@ -222,7 +222,7 @@ const myList = await listDocs({
 });
 ```
 
-The function accepts various optional parameters, including a matcher (a regex applied to the document keys and descriptions), pagination options, and sorting order.
+The function **accepts various optional parameters**, including a matcher (a regex applied to the document keys and descriptions), pagination options, and sorting order.
 
 ```javascript
 import { listDocs } from "@junobuild/core";
@@ -245,6 +245,18 @@ Sorting can be applied descending or ascending to following fields:
 - `created_at`
 
 Options `matcher`, `paginate` and `order` can be use together.
+
+The function **returns various information**, in the form of an object whose interface is given below.
+
+```javascript
+{
+  items: []; // The data - array of documents
+  items_length: bigint; // The numbers of items - basically items.length
+  items_page?: bigint; // If the query is paginated, at what page (starting from 0) do the items find the place
+  matches_length: bigint; // The total number of matching results
+  matches_pages?: bigint; // If the query is paginated, the total number (starting from 0) of pages
+}
+```
 
 ## Delete a document
 

--- a/docs/build/datastore.md
+++ b/docs/build/datastore.md
@@ -248,10 +248,10 @@ Options `matcher`, `paginate` and `order` can be use together.
 
 The function **returns various information**, in the form of an object whose interface is given below.
 
-```javascript
+```typescript
 {
   items: []; // The data - array of documents
-  items_length: bigint; // The numbers of items - basically items.length
+  items_length: bigint; // The number of documents - basically items.length
   items_page?: bigint; // If the query is paginated, at what page (starting from 0) do the items find the place
   matches_length: bigint; // The total number of matching results
   matches_pages?: bigint; // If the query is paginated, the total number (starting from 0) of pages

--- a/docs/build/storage.md
+++ b/docs/build/storage.md
@@ -135,6 +135,18 @@ The `listAssets` function -- in addition to specifying the collection to query -
 - `paginate`: an object used to query a subset of the assets
 - `order`: requests entries sorted in ascending or descending order
 
+The function **returns various information**, in the form of an object whose interface is given below.
+
+```javascript
+{
+  items: []; // The data - array of assets
+  items_length: bigint; // The numbers of items - basically items.length
+  items_page?: bigint; // If the query is paginated, at what page (starting from 0) do the items find the place
+  matches_length: bigint; // The total number of matching results
+  matches_pages?: bigint; // If the query is paginated, the total number (starting from 0) of pages
+}
+```
+
 ## Delete asset
 
 To delete an asset, you only need to provide its `fullPath`. Unlike the [datastore](datastore.md), there is no timestamp validation performed when deleting an asset.

--- a/docs/build/storage.md
+++ b/docs/build/storage.md
@@ -137,10 +137,10 @@ The `listAssets` function -- in addition to specifying the collection to query -
 
 The function **returns various information**, in the form of an object whose interface is given below.
 
-```javascript
+```typescript
 {
   items: []; // The data - array of assets
-  items_length: bigint; // The numbers of items - basically items.length
+  items_length: bigint; // The number of assets - basically items.length
   items_page?: bigint; // If the query is paginated, at what page (starting from 0) do the items find the place
   matches_length: bigint; // The total number of matching results
   matches_pages?: bigint; // If the query is paginated, the total number (starting from 0) of pages


### PR DESCRIPTION
Added the return type for `listAssets` and `listDocs`, which resolves issue #86. 
I have attached an image to ensure the format is correct.

![image](https://github.com/junobuild/docs/assets/129579058/acd6fb31-75d5-46a1-be2a-a8974bdf518c)

The format is the same for `listAssets`.