### PR TITLE
docs: added minimal docker version on MacBook for local dev

### DIFF
--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -13,7 +13,7 @@ When you get started with Juno, you are using your smart contract deployed on th
 
 ## Before you begin
 
-Make sure you have Docker installed on your machine ([Windows](https://docs.docker.com/desktop/install/windows-install/), [MacOS](https://docs.docker.com/desktop/install/mac-install/), or [Linux](https://docs.docker.com/desktop/install/linux-install/)).
+Make sure you have Docker installed on your machine ([Windows](https://docs.docker.com/desktop/install/windows-install/), [MacOS](https://docs.docker.com/desktop/install/mac-install/), or [Linux](https://docs.docker.com/desktop/install/linux-install/)). For MacBooks with M processors, it is important to use Docker Desktop version 4.25.0 or later, ideally the latest available version.
 
 ---
 


### PR DESCRIPTION
Closes #136 

## Description:

Mentioned the minimal version of Docker Desktop in the "Before You Begin" section of the "Local Development" in the documentation.