### PR TITLE
docs: update GH action versions in the Guides & Examples

### DIFF
--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## **Description:**

- Updated GitHub Actions in the [GH actions - Guides and Examples](https://juno.build/docs/guides/github-actions):
  - Bumped `actions/checkout@v3` to `actions/checkout@v4`.
  - Bumped `actions/setup-node@v3` to `actions/setup-node@v4`.

Resolves https://github.com/junobuild/juno-action/issues/3