### PR TITLE
feat: remove THE REGISTRY from showcase (project is deprecated?)

### DIFF
--- a/showcase.json
+++ b/showcase.json
@@ -30,13 +30,6 @@
     "img": "/showcase/aegir.jpg"
   },
   {
-    "title": "THE REGISTRY",
-    "url": "https://theregistry.app",
-    "description": "PayString provider on the internet computer, allowing easy multichain payments.",
-    "img": "https://theregistry.app/banner.jpg",
-    "twitter": "@the_registry_"
-  },
-  {
     "title": "ICPFA",
     "url": "https://icpfa.org",
     "description": "The Future of Community Football.",


### PR DESCRIPTION
Project THE REGISTRY seems to have been deprecated. https://theregistry.app leads to a 404.