### PR TITLE
docs: add missing entries to roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,14 +29,17 @@ Last update: August 8, 2024
 - **Payments SDK**: Allowing developers to integrate payment solutions seamlessly into their dApps using signer standards.
 - **Developer Wallet**: Introducing a dedicated developer wallet, enabling developers to manage earnings, payments, and transactions securely and efficiently within the Juno ecosystem.
 - **Third-Party Authentication**: Supporting integration with more third-party authentication providers.
+- **Standalone Analytics**: Providing the existing analytics solution as a standalone product, offering comprehensive insights and performance on Web3 metrics for any developers or product owners.
 
 ---
 
 ## H2 2025
 
+- **Secure Team Collaboration**: Introducing support for secure team collaboration, enabling multiple developers to work together efficiently and securely.
+- **Enhanced Management Tools**: Offering advanced administration capabilities such as automatic top-up and batch upgrade of smart contracts.
+- **GitHub and GitLab**: Automate deployment processes and integrate, including preview deployment, with deeper integration with GitHub and GitLab.
 - **Subscription-Based Model**: Launching a subscription-based model to provide premium features and services, including secure team collaboration and enhanced management tools.
 - **Regions Selection**: Allowing developers to choose a specific subnet for deploying new smart contracts, enabling projects to comply with regional regulations, and enhance data sovereignty by being located in areas such as Europe.
-- **Standalone Analytics**: Providing the existing analytics solution as a standalone product, offering comprehensive insights and performance on Web3 metrics for any developers or product owners.
 
 ---
 


### PR DESCRIPTION
When I updated the roadmap in #163, I missed some copy / paste and therefore few entries were missing in the roadmap as provided in the white paper.