### PR TITLE
docs: adjust frameworks names in guides

### DIFF
--- a/docs/guides/angular.md
+++ b/docs/guides/angular.md
@@ -33,7 +33,7 @@ Additionally, it covers how to develop against a production environment or local
 npm create juno@latest
 ```
 
-### Path B: Integrate Juno into an existing Next.js app
+### Path B: Integrate Juno into an existing Angular app
 
 1. Add the Juno SDK:
 

--- a/docs/guides/astro.md
+++ b/docs/guides/astro.md
@@ -32,7 +32,7 @@ Additionally, it covers how to develop against a production environment or local
 npm create juno@latest
 ```
 
-### Path B: Integrate Juno into an existing Next.js app
+### Path B: Integrate Juno into an existing Astro app
 
 1. Add the Juno SDK:
 

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -33,7 +33,7 @@ Additionally, it covers how to develop against a production environment or local
 npm create juno@latest
 ```
 
-### Path B: Integrate Juno into an existing Next.js app
+### Path B: Integrate Juno into an existing React app
 
 1. Add the Juno SDK:
 

--- a/docs/guides/sveltekit.md
+++ b/docs/guides/sveltekit.md
@@ -33,7 +33,7 @@ Additionally, it covers how to develop against a production environment or local
 npm create juno@latest
 ```
 
-### Path B: Integrate Juno into an existing Next.js app
+### Path B: Integrate Juno into an existing SvelteKit app
 
 1. Add the Juno SDK:
 

--- a/docs/guides/vue.md
+++ b/docs/guides/vue.md
@@ -33,7 +33,7 @@ Additionally, it covers how to develop against a production environment or local
 npm create juno@latest
 ```
 
-### Path B: Integrate Juno into an existing Next.js app
+### Path B: Integrate Juno into an existing Vue app
 
 1. Add the Juno SDK:
 


### PR DESCRIPTION
Not really sure if that was intentional, but it feels like the correct name should be the one of the framework to which the documentation refers.