### PR TITLE
fix: default memory allocation for Datastore is stable

### DIFF
--- a/docs/build/datastore.md
+++ b/docs/build/datastore.md
@@ -60,7 +60,7 @@ A rule is assigned to a collection to define read and write permissions, which c
 
 ### Memory
 
-When you create a collection, it's assigned to either heap or stable memory. This assignment is permanent and cannot be changed once the collection is created. The default allocation is `heap` memory.
+When you create a collection, it's assigned to either heap or stable memory. This assignment is permanent and cannot be changed once the collection is created. The default allocation is `stable` memory.
 
 ---
 


### PR DESCRIPTION
There was a typo / leftover. The Datastore now also use "stable" as default.

Resolves #192