### PR TITLE
docs: remove build from GitHub Actions

### DIFF
--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -74,7 +74,8 @@ import { defineConfig } from "@junobuild/config";
 export default defineConfig({
   satellite: {
     id: "qsgjb-riaaa-aaaaa-aaaga-cai", // Replace with your satellite ID
-    source: "dist" // Replace with your build output directory
+    source: "dist", // Replace with your build output directory
+    predeploy: ["npm run build"] // Adjust based on your package manager
   }
 });
 ```
@@ -113,9 +114,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
       - name: Deploy to Juno
         uses: junobuild/juno-action@main
         with:
@@ -124,24 +122,38 @@ jobs:
           JUNO_TOKEN: ${{ secrets.JUNO_TOKEN }}
 ```
 
-Whenever code is pushed to your `main` branch, this action performs the following tasks: it checks out your repository, installs dependencies, and builds your application. It then utilizes the [junobuild/juno-action](https://github.com/junobuild/juno-action) GitHub Action to deploy your dapp.
+Whenever code is pushed to your `main` branch, this action performs the following tasks: it checks out your repository, installs dependencies. It then utilizes the [junobuild/juno-action](https://github.com/junobuild/juno-action) GitHub Action to build and deploy your dapp.
 
-Make sure to adapt the code according to your specific requirements, such as adjusting the branch name and package manager command.
+That's it—your pipeline is set! 🥳
 
-:::tip
+---
 
-Before configuring the action, take the following factors into consideration:
+## Additional Notes
 
-- **Build Reproducibility**: Only new resources will be deployed to your satellite. Changes are detected through sha256 comparison. Therefore, ensuring the build reproducibility of your application is crucial to accurately identify and deploy the necessary updates.
-- **Deployment Costs**: Deploying new assets consumes [cycles], and the cost increases with both the frequency of deployments and the number of items to deploy. While the above code snippet demonstrates a more frequent lifecycle, as a general recommendation, consider minimizing your deployment expenses with less frequent deployments. For instance, you can trigger the action on releases instead.
+Here are some notes about the setup.
+
+### Build
+
+If your `juno.config` file does not build your application using a `predeploy` field, you might need to add an additional step to your YAML file to do so:
+
+```yaml
+- name: Build
+  run: npm run build
+```
+
+### Reproducibility
+
+Only new resources will be deployed to your satellite. Changes are detected through sha256 comparison. Therefore, ensuring the build reproducibility of your application is crucial to accurately identify and deploy the necessary updates.
+
+### Deployment Costs
+
+Deploying new assets consumes [cycles], and the cost increases with both the frequency of deployments and the number of items to deploy. While the above code snippet demonstrates a more frequent lifecycle, as a general recommendation, consider minimizing your deployment expenses with less frequent deployments. For instance, you can trigger the action on releases instead.
 
 ```yaml
 on:
   release:
     types: [released]
 ```
-
-:::
 
 [CLI]: ../miscellaneous/cli.mdx
 [satellite]: ../terminology.md#satellite


### PR DESCRIPTION
We can now leverage the `predeploy` option instead.