### PR TITLE
feat: reorder misc and integrate provisioning options

### DIFF
--- a/docs/create-a-satellite.mdx
+++ b/docs/create-a-satellite.mdx
@@ -24,30 +24,5 @@ Before integrating Juno into your project, you need to create a [satellite].
 6. Once the process is complete, click **Continue** to access the overview page.
 7. You are all set! Start Building now 🚀
 
----
-
-## Advanced Options
-
-In the creation wizard, there are advanced options available for more experienced developers or those with specific requirements.
-
-### Selecting a Subnet
-
-If you wish to have more control over where your satellite is deployed, you can select the [subnet] for deployment during the creation process.
-
-Below is a list of available subnets with relevant metadata to help you choose the most appropriate one:
-
-:::note
-
-Satellites operating on larger subnets with more nodes will incur higher cycle costs compared to those running on the standard 13-node subnets. However, this increased cost comes with the benefit of enhanced security due to the greater size of the subnet.
-
-For standard applications, we generally recommend using the standard subnets and staying on the same subnets as Juno.
-
-:::
-
-import Subnets from "./components/subnets.md";
-
-<Subnets />
-
 [satellite]: terminology.md#satellite
 [Internet Identity]: terminology.md#internet-identity
-[subnet]: terminology.md#subnet

--- a/docs/miscellaneous/best-practices.md
+++ b/docs/miscellaneous/best-practices.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 7
----
-
 # Best Practices
 
 This page provides recommendations to improve your application when developing and deploying with Juno.

--- a/docs/miscellaneous/controllers.md
+++ b/docs/miscellaneous/controllers.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 5
----
-
 # Controllers
 
 Controllers play a crucial role in granting permissions to mission controls and satellites within Juno.

--- a/docs/miscellaneous/memory.md
+++ b/docs/miscellaneous/memory.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 4
----
-
 # Memory
 
 A [satellite] can store data using two types of memory: `heap` and `stable`. While both types are forms of random-access memory that only exist as long as the smart contract lives, they can be compared to a familiar analogy. Think of `heap` as similar to the RAM in a computer, and `stable` as more akin to ROM.

--- a/docs/miscellaneous/provisioning-options.mdx
+++ b/docs/miscellaneous/provisioning-options.mdx
@@ -1,0 +1,25 @@
+# Provisioning Options
+
+The creation wizard for Satellites and Orbiters includes advanced provisioning options for developers who need more control.
+
+---
+
+### Selecting a Subnet
+
+If you want more control over where your module is provisioned, you can select a [subnet] during the creation process.
+
+Below is a list of available subnets with relevant metadata to help you choose the most appropriate one:
+
+:::note
+
+Satellites and Orbiters running on larger subnets with more nodes will incur higher cycle costs compared to those on the standard 13-node subnets. However, this increased cost comes with the benefit of enhanced security due to the greater size of the subnet.
+
+For most applications, we recommend using the default subnets and staying on the same subnet as Juno.
+
+:::
+
+import Subnets from "../components/subnets.md";
+
+<Subnets />
+
+[subnet]: terminology.md#subnet

--- a/docs/miscellaneous/wallet.md
+++ b/docs/miscellaneous/wallet.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 8
----
-
 # Wallet
 
 This section provides guidance on managing your assets and cycles with your [wallet](../terminology.md#wallet), which are essential for maintaining and providing enough resources for your modules in the Juno ecosystem.

--- a/docs/miscellaneous/workarounds.md
+++ b/docs/miscellaneous/workarounds.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 9
----
-
 # Workarounds
 
 This page is dedicated to helping you make the most of Juno features, even when some functionalities are not yet fully supported out of the box. Below, you'll find practical workarounds and guidance for processes which in the future will be resolved by features planned in the [roadmap](../white-paper/roadmap.mdx).


### PR DESCRIPTION
Moving the subnet out of the "Create satellite" page makes it more readable, therefore better for the onboarding, and also makes sense as the same options are available for Orbiter as well.