### PR TITLE
Add "doc" Definition to Terminology Documentation

### DIFF
--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -33,6 +33,10 @@ Think of cycles like prepaid mobile data:
 
 Learn more about [computation and storage costs](https://internetcomputer.org/docs/current/developer-docs/gas-cost).
 
+## Doc (Document of the Datastore)
+
+"doc" is a commonly used shorthand in Juno for a "document of the Datastore". Wherever you see the term "doc" in the codebase or documentation, it refers specifically to a document entity managed by the Datastore. This abbreviation is used for brevity and consistency throughout the project.
+
 ## ICP
 
 The ICP token is the cryptocurrency used to pay for transactions on Juno's [infrastructure].


### PR DESCRIPTION
This PR addresses issue #395  by adding an entry for the shorthand "doc" in the terminology documentation.

The term "doc" is frequently used in the codebase and documentation to refer to a "document of the Datastore," but was previously undefined.

This update makes using "doc" explicit and helps clarify its meaning for users and contributors.