### PR TITLE
fix: tagname not defined on typed init

### DIFF
--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -15,7 +15,7 @@ export default function Hero(): JSX.Element {
   useEffect(() => {
     let typed: Typed | undefined;
 
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       typed = new Typed(el.current, {
         strings: ["Run", "Ship", "Build"],
         typeSpeed: 50,
@@ -29,6 +29,7 @@ export default function Hero(): JSX.Element {
     }, 2500);
 
     return () => {
+      clearTimeout(timeout);
       typed?.destroy();
     };
   }, []);


### PR DESCRIPTION
If user navigates quickly, it's possible that the deferred typed initialization starts when the landing is not displayed.

Long story short, I forgot a clear timeout on destroy. My bad.