### PR TITLE
docs: split juno version in two commands (version and status)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -280,6 +280,14 @@ import Open from "./cli/open.md";
 
 ---
 
+### Status
+
+import Status from "./cli/status.md";
+
+<Status />
+
+---
+
 ### Version
 
 import Version from "./cli/version.md";

--- a/docs/reference/cli/status.md
+++ b/docs/reference/cli/status.md
@@ -1,0 +1,13 @@
+Check the version of the modules and CLI.
+
+```
+Usage: juno init [options]
+
+Options:
+  -c, --cli             Check only the version of the CLI.
+  -m, --mode            Choose which environment to use (production, staging, development). Defaults to production if omitted.
+  -p, --profile         Specify an optional profile to use (e.g. personal, team). Useful when managing multiple Mission Controls.
+  --container-url       Override a custom container URL. If not provided, defaults to production or the local container in development mode.
+  --console-url         Specify a custom URL to access the developer Console.
+  -h, --help            Output usage information.
+```

--- a/scripts/cli-to-md.sh
+++ b/scripts/cli-to-md.sh
@@ -7,7 +7,7 @@ function generate_command_markdown() {
   eval "juno "$cmd" --headless --help --doc" | sed 's/\x1b\[[0-9;]*m//g' > docs/reference/cli/"$output".md
 }
 
-COMMANDS=clear,config,deploy,dev,functions,changes,init,login,logout,open,snapshot,start,stop,upgrade,version,whoami
+COMMANDS=clear,config,deploy,dev,functions,changes,init,login,logout,open,snapshot,start,stop,upgrade,version,status,whoami
 
 for cmd in $(echo $COMMANDS | sed "s/,/ /g"); do
   generate_command_markdown "$cmd"


### PR DESCRIPTION
Relates to https://github.com/junobuild/cli/pull/333