### PR TITLE
feat: ignore tags route in llms.txt

### DIFF
--- a/plugins/docusaurus.llms.plugin.ts
+++ b/plugins/docusaurus.llms.plugin.ts
@@ -62,7 +62,7 @@ export default function docusaurusPluginLLMs(
       const allRoutes = Object.keys(routesBuildMetadata).filter(
         (path) =>
           path.startsWith(`/${docsDir}/`) &&
-          [`/category/`, ...ignorePaths].find((pathToIgnore) =>
+          [`/category/`, "/tags/", ...ignorePaths].find((pathToIgnore) =>
             path.includes(pathToIgnore)
           ) === undefined
       );


### PR DESCRIPTION
We don't want to add tags (used in #560) to the `llms.txt` files.