### PR TITLE
feat: use brotli and replace for precompress

### DIFF
--- a/juno.config.ts
+++ b/juno.config.ts
@@ -253,6 +253,18 @@ export default defineConfig({
       headers,
       redirects
     },
+    precompress: [
+      {
+        pattern: "**/*.+(js|mjs|css)",
+        algorithm: "brotli",
+        mode: "replace"
+      },
+      {
+        pattern: "**/*.html",
+        algorithm: "brotli",
+        mode: "both"
+      }
+    ],
     predeploy: ["npm run build"]
   },
   orbiter: {


### PR DESCRIPTION
Docusaurus lack of reproducibility is an issue as we have to deploy to many files all the times. Therefore the replace strategy to avoid to upload raw js files.

Since we are going to clear before deploy to apply this, let's switch to brotli which seems to generally better compress than gzip.